### PR TITLE
Fix 386 structs to make test.go build and run

### DIFF
--- a/sdl/structs_386.go
+++ b/sdl/structs_386.go
@@ -33,6 +33,7 @@ type Color struct {
 	R      uint8
 	G      uint8
 	B      uint8
+	Alpha  uint8
 	Unused uint8
 }
 
@@ -68,15 +69,17 @@ type ActiveEvent struct {
 }
 
 type KeyboardEvent struct {
-	Type   uint8
-	Which  uint8
-	State  uint8
-	Pad0   [1]byte
-	Keysym Keysym
+	Type      uint32
+	Timestamp uint32
+	WindowId  uint32
+	State     uint8
+	Repeat    uint8
+	Pad0      [2]byte
+	Keysym    Keysym
 }
 
 type MouseMotionEvent struct {
-	Type  uint8
+	Type  uint32
 	Which uint8
 	State uint8
 	Pad0  [1]byte
@@ -87,7 +90,7 @@ type MouseMotionEvent struct {
 }
 
 type MouseButtonEvent struct {
-	Type   uint8
+	Type   uint32
 	Which  uint8
 	Button uint8
 	State  uint8
@@ -158,8 +161,8 @@ type SysWMEvent struct {
 }
 
 type Event struct {
-	Type uint8
-	Pad0 [19]byte
+	Type uint32
+	Pad0 [31]byte
 }
 
 type Keysym struct {


### PR DESCRIPTION
Hey Scott. I'm not even sure if Go-SDL2 is still being supported, or even the basis for different structs between 386 and Amd64 (I'm not very familiar with Go or SDL, screwing around with gaming libraries is just a hobby) but I managed to fix the parts that were causing test.go to fail to build on my machine (32 bit Ubuntu 13.04 installed on a  64 bit MBP).

To me it looked like most of the 386's structs were just out of sync with the changes to the Amd64 structs, so I assumed that there wasn't any special optimization decisions, at least where the code was breaking. I hesitated to do drastic changes because I didn't understand the need for these structs to be different in the first place.
